### PR TITLE
fix: scss deprecations

### DIFF
--- a/src/app/modules/authors/components/author-list-item/author-list-item.component.scss
+++ b/src/app/modules/authors/components/author-list-item/author-list-item.component.scss
@@ -1,5 +1,5 @@
-@use "sass:math";
-@import "../../../../shared/styles/base";
+@use 'sass:math';
+@use '../../../../shared/styles' as *;
 
 $authorListItemHeight: 100px;
 

--- a/src/app/modules/posts/components/post-tile/post-tile.component.scss
+++ b/src/app/modules/posts/components/post-tile/post-tile.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../shared/styles/base';
+@use '../../../../shared/styles' as *;
 
 .ap-post-tile {
     @extend %ap-card;

--- a/src/app/modules/posts/pages/post-list/post-list.component.scss
+++ b/src/app/modules/posts/pages/post-list/post-list.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../shared/styles/base';
+@use '../../../../shared/styles' as *;
 
 .ap-post-list-container {
     .ap-post-list-header {

--- a/src/app/shared/components/search-input/search-input.component.scss
+++ b/src/app/shared/components/search-input/search-input.component.scss
@@ -1,4 +1,5 @@
-@import '../../styles/base';
+@use 'sass:color';
+@use '../../styles' as *;
 
 .ap-search-input {
     position: relative;
@@ -6,7 +7,7 @@
         position: absolute;
         left: 10px;
         top: 5px;
-        color: darken($apLightGray, 10);
+        color: color.scale($apLightGray, $lightness: -10%);
     }
     input {
         @extend %ap-input;

--- a/src/app/shared/styles/_index.scss
+++ b/src/app/shared/styles/_index.scss
@@ -1,0 +1,2 @@
+@forward './placeholders';
+@forward './variables';

--- a/src/app/shared/styles/_placeholders.scss
+++ b/src/app/shared/styles/_placeholders.scss
@@ -1,8 +1,5 @@
-@use "sass:math";
-
-$apBorderRadius: 2.5px;
-$apAccentColor: lighten(salmon, 2.5);
-$apLightGray: #f3f3f3;
+@use 'sass:math';
+@use './variables' as *;
 
 %ap-list-item {
     border-radius: math.div($apBorderRadius, 2);

--- a/src/app/shared/styles/_variables.scss
+++ b/src/app/shared/styles/_variables.scss
@@ -1,0 +1,6 @@
+@use 'sass:color';
+
+$apBorderRadius: 2.5px;
+
+$apAccentColor: color.scale(salmon, $lightness: 2.5%);
+$apLightGray: #f3f3f3;


### PR DESCRIPTION
Fixing SCSS deprecations.

**Includes**:
- moving away from `@import` to `@use`,
- moving away from `darken`/`lighten` to their module counterparts.