### PR TITLE
ci: cache npm dependencies, use latest versions of actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,17 +15,22 @@ jobs:
     env:
       HUSKY: 0
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Setup environment
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
+
       - name: Install dependencies
         run: npm ci
-      - name: Build
+
+      - name: Build project
         run: npm run build:ci
-      - name: Test [UNIT]
+
+      - name: Run tests [UNIT]
         run: npm run test
-      - name: Test [E2E]
+
+      - name: Run tests [E2E]
         run: npm run e2e

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,7 +24,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --no-audit --no-fund
 
       - name: Build project
         run: npm run build:ci


### PR DESCRIPTION
Verification workflow tweaks including
- caching `npm` dependencies,
- using latest versions of actions.